### PR TITLE
Removing the need for the token to be required in the main file.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Read the README.md file, for information on how to fill these out!
 # Bot-related Information:
-CELESTIA_TOKEN=
+DISCORD_TOKEN=
 CELESTIA_PREFIX=c.
 CELESTIA_ID=
 

--- a/celestia.js
+++ b/celestia.js
@@ -7,7 +7,6 @@ const readdir = promisify(require("fs").readdir);
 const Enmap = require("enmap");
 const klaw = require("klaw");
 const path = require("path");
-const { CELESTIA_TOKEN } = process.env;
 
 // Client Settings
 class Celestia extends Discord.Client {

--- a/celestia.js
+++ b/celestia.js
@@ -144,7 +144,7 @@ const init = async () => {
     client.levelCache[thisLevel.name] = thisLevel.level;
   }
 
-  client.login(CELESTIA_TOKEN);
+  client.login();
 
 };
 


### PR DESCRIPTION
Removing the need to import the token from the env file as discord.js already has inbuilt functionality to check for DISCORD_TOKEN before it is set.
```js
Object.defineProperty(this, 'token', { writable: true });
    if (!browser && !this.token && 'DISCORD_TOKEN' in process.env) {
      /**
       * Authorization token for the logged in bot
       * <warn>This should be kept private at all times.</warn>
       * @type {?string}
       */
      this.token = process.env.DISCORD_TOKEN;
    } else {
      this.token = null;
    }
```


**Semantic versioning classification:**  
- This PR changes the code in some way
  - [ ] SEMVER patch (bug fix)
  - [x] SEMVER minor (commands or args added)
  - [ ] SEMVER major (commands removed or renamed, args moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to the README.
